### PR TITLE
Added TXLED0 empty check

### DIFF
--- a/Firmware/UsbParMarkerV2/UsbParMarkerV2/UsbParMarkerV2.ino
+++ b/Firmware/UsbParMarkerV2/UsbParMarkerV2/UsbParMarkerV2.ino
@@ -47,7 +47,19 @@ void setup() {
   Serialno = readStringFromEEPROM(10);
   HwVer= readStringFromEEPROM(20);
   Version = String(HwVer + ":" + SwVer);   // Set HW version always 
-}
+
+// #################################### Keep the code lines below in the same order ################################################
+  TXLED0
+  // The macro TXLED0 above is intentionally there to make compilation crash if it is defined as "PORTD |= (1<<5)".
+  // TXLED0 should be defined empty, or it will cause DATA3 (and LED3 if enabled) to turn on when sending serial data (an answer)
+  // like "Pong,UsbParMarker" after receiving the "P" command for example.
+  // Using "#undef TXLED0" does not work (any longer) as apparently the TXLED0 macro is preprocessed before this ino file.
+  // To prevent this problem (and this error); change "#define TXLED0			PORTD |= (1<<5)" to "#define TXLED0" on line 95 in:
+  // C:\Users\<USER>\AppData\Local\Arduino15\packages\arduino\hardware\avr\1.8.6\variants\leonardo\pins_arduino.h
+
+} // Compilation error on this line? Read comments above!
+// #################################### Keep the code lines above in the same order ################################################
+
 
 void loop() {
   if (Serial.baud() == 115200 || Serial.baud() == 9600 ) {    //data mode

--- a/Firmware/UsbParMarkerV2/UsbParMarkerV2/UsbParMarkerV2.ino
+++ b/Firmware/UsbParMarkerV2/UsbParMarkerV2/UsbParMarkerV2.ino
@@ -21,7 +21,7 @@
 */
 
 #undef TX_RX_LED_INIT  //DDRD |= (1<<5), DDRB |= (1<<0)
-#undef TXLED0    //  PORTD |= (1<<5)
+//#undef TXLED0    //  PORTD |= (1<<5)
 #undef TXLED1    //  PORTD &= ~(1<<5)
 #undef RXLED0    //  PORTB |= (1<<0)
 #undef RXLED1    //  PORTB &= ~(1<<0)


### PR DESCRIPTION
Added a somewhat strange way to test TXLED0 to be defined empty. Compilation will crash to prevent one from building the firmware without changing file *pins_arduino.h*. This seems to be the only way to prevent DATA/LED3 turning on after an answer to a command.